### PR TITLE
Use Github Actions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -28,7 +28,7 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  check_and_test:
+  build:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -64,8 +64,43 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --workspace
+
+  test: 
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache-cargo
+        with:
+          # The paths are taken from
+          # https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        id: cache-sgx
+        with:
+          path: |
+            ${{ env.SGX_SDK_DEST }}/sgxsdk
+          key: ${{ runner.os }}-sgx-${{ env.SGX_SDK_URL }}
+      - name: Install Intel SGX SDK
+        if: steps.cache-sgx.outputs.cache-hit != 'true'
+        run: |
+          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          chmod +x ${SGX_SDK_INSTALLER}
+          echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   format:
+    name: Format
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -28,90 +29,12 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  build:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        id: cache-cargo
-        with:
-          # The paths are taken from
-          # https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2
-        id: cache-sgx
-        with:
-          path: |
-            ${{ env.SGX_SDK_DEST }}/sgxsdk
-          key: ${{ runner.os }}-sgx-${{ env.SGX_SDK_URL }}
-      - name: Install Intel SGX SDK
-        if: steps.cache-sgx.outputs.cache-hit != 'true'
-        run: |
-          curl -LsSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
-          chmod +x ${SGX_SDK_INSTALLER}
-          echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace
-
-  test: 
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        id: cache-cargo
-        with:
-          # The paths are taken from
-          # https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-
-      - uses: actions/cache@v2
-        id: cache-sgx
-        with:
-          path: |
-            ${{ env.SGX_SDK_DEST }}/sgxsdk
-          key: ${{ runner.os }}-sgx-${{ env.SGX_SDK_URL }}
-      - name: Install Intel SGX SDK
-        if: steps.cache-sgx.outputs.cache-hit != 'true'
-        run: |
-          curl -LsSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
-          chmod +x ${SGX_SDK_INSTALLER}
-          echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace
-
   build_and_test:
-    name: Build and Test (experimental)
+    name: Build and Test
     runs-on: ubuntu-18.04
     env:
       SCCACHE_TAR_URL: https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz
-      SCCACHE_CACHE_SIZE: "4G"
+      SCCACHE_CACHE_SIZE: "1G"
     steps:
       - uses: actions/checkout@v2
       - name: Setup environment variables for subsequent steps
@@ -195,6 +118,7 @@ jobs:
         run: sccache -s    
 
   clippy:
+    name: Clippy
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,3 @@
-
 name: Rust
 
 on:
@@ -9,28 +8,39 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+env:
+  INTEL_SGX_SDK: https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
+
 jobs:
-  check:
-    runs-on: ubuntu-latest
+  format:
+    runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: install toolchain and other components
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        components: rustfmt
-    - name: install wasm
-      run: ./scripts/init.sh
-    - name: format check
-      run: cargo fmt -- --check
-    - name: run build on default members
-      run: cargo build
-    - name: unit test
-      run: cargo test
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  check:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Intel SGX SDK
+        run: |
+          curl -sSf $INTEL_SGX_SDK > /tmp/intel_sgx_sdk_installer
+          chmod +x /tmp/intel_sgx_sdk_installer
+          echo -e 'no\n/opt/intel' | /tmp/intel_sgx_sdk_installer
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: rustfmt
+          target: wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -10,8 +10,9 @@ on:
   workflow_dispatch:
 
 env:
-  INTEL_SGX_SDK: https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
-  INTEL_SGX_SDK_INSTALL_PATH: /opt
+  SGX_SDK_URL: https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
+  SGX_SDK_INSTALLER: /tmp/sgxsdk_installer
+  SGX_SDK_DEST: /opt
 
 jobs:
   format:
@@ -31,11 +32,32 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache-cargo
+        with:
+          # The paths are taken from
+          # https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        id: cache-sgx
+        with:
+          path: |
+            ${{ env.SGX_SDK_DEST }}/sgxsdk
+          key: ${{ runner.os }}-sgx-${{ env.SGX_SDK_URL }}
       - name: Install Intel SGX SDK
+        if: steps.cache-sgx.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${INTEL_SGX_SDK} > /tmp/intel_sgx_sdk_installer
-          chmod +x /tmp/intel_sgx_sdk_installer
-          echo -e 'no\n${INTEL_SGX_SDK_INSTALL_PATH}' | /tmp/intel_sgx_sdk_installer
+          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          chmod +x ${SGX_SDK_INSTALLER}
+          echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -51,13 +73,21 @@ jobs:
 
   clippy:
     runs-on: ubuntu-18.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache-sgx
+        with:
+          path: |
+            ${{ env.SGX_SDK_DEST }}/sgxsdk
+          key: ${{ runner.os }}-sgx-${{ env.SGX_SDK_URL }}
       - name: Install Intel SGX SDK
+        if: steps.cache-sgx.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${INTEL_SGX_SDK} > /tmp/intel_sgx_sdk_installer
-          chmod +x /tmp/intel_sgx_sdk_installer
-          echo -e 'no\n${INTEL_SGX_SDK_INSTALL_PATH}' | /tmp/intel_sgx_sdk_installer
+          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          chmod +x ${SGX_SDK_INSTALLER}
+          echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   INTEL_SGX_SDK: https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.12.100.3.bin
+  INTEL_SGX_SDK_INSTALL_PATH: /opt
 
 jobs:
   format:
@@ -26,22 +27,22 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  check:
+  build:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Intel SGX SDK
         run: |
-          curl -sSf $INTEL_SGX_SDK > /tmp/intel_sgx_sdk_installer
+          curl -sSf ${INTEL_SGX_SDK} > /tmp/intel_sgx_sdk_installer
           chmod +x /tmp/intel_sgx_sdk_installer
-          echo -e 'no\n/opt/intel' | /tmp/intel_sgx_sdk_installer
+          echo -e 'no\n${INTEL_SGX_SDK_INSTALL_PATH}' | /tmp/intel_sgx_sdk_installer
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --workspace
 
   test:
@@ -50,9 +51,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Intel SGX SDK
         run: |
-          curl -sSf $INTEL_SGX_SDK > /tmp/intel_sgx_sdk_installer
+          curl -sSf ${INTEL_SGX_SDK} > /tmp/intel_sgx_sdk_installer
           chmod +x /tmp/intel_sgx_sdk_installer
-          echo -e 'no\n/opt/intel' | /tmp/intel_sgx_sdk_installer
+          echo -e 'no\n${INTEL_SGX_SDK_INSTALL_PATH}' | /tmp/intel_sgx_sdk_installer
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -68,9 +69,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Intel SGX SDK
         run: |
-          curl -sSf $INTEL_SGX_SDK > /tmp/intel_sgx_sdk_installer
+          curl -sSf ${INTEL_SGX_SDK} > /tmp/intel_sgx_sdk_installer
           chmod +x /tmp/intel_sgx_sdk_installer
-          echo -e 'no\n/opt/intel' | /tmp/intel_sgx_sdk_installer
+          echo -e 'no\n${INTEL_SGX_SDK_INSTALL_PATH}' | /tmp/intel_sgx_sdk_installer
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -107,17 +107,22 @@ jobs:
           args: --workspace
 
   build_and_test:
+    name: Build and Test (experimental)
     runs-on: ubuntu-18.04
     env:
       SCCACHE_TAR_URL: https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz
       SCCACHE_CACHE_SIZE: "4G"
     steps:
       - uses: actions/checkout@v2
+      - name: Setup environment variables for subsequent steps
+        run: |
+          echo "$HOME/.local/bin/" >> $GITHUB_PATH
+          echo "SCCACHE=$HOME/.local/bin/sccache" >> $GITHUB_ENV
       - uses: actions/cache@v2
         id: cache-sccache
         with:
           path: |
-            /usr/local/bin/sccache
+            ${{ env.SCCACHE }}
           key: ${{ runner.os }}-sccache-${{ env.SCCACHE_TAR_URL }}
       - uses: actions/cache@v2
         id: cache-cargo
@@ -144,13 +149,18 @@ jobs:
         with:
           path: |
             ~/.cache/sccache
-          key: ${{ runner.os }}-sccache-local-disk
+          key: ${{ runner.os }}-sccache-local-disk-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-local-disk-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-sccache-local-disk
       - name: Install sccache
         if: steps.cache-sccache.outputs.cache-hit != 'true'
+        id: install-sccache
         run: |
           curl -LsSf ${SCCACHE_TAR_URL} > /tmp/sccache.tar.gz
-          sudo tar axvf /tmp/sccache.tar.gz --strip-components=1 -C /usr/local/bin --wildcards --no-anchored 'sccache'
-          sudo chmod +x /usr/local/bin/sccache
+          mkdir -p $(dirname $SCCACHE)
+          tar axvf /tmp/sccache.tar.gz --strip-components=1 -C $(dirname $SCCACHE) --wildcards --no-anchored 'sccache'
+          chmod +x ${SCCACHE}
           sccache --version
           sccache -s
       - name: Install Intel SGX SDK
@@ -165,13 +175,19 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         env:
-          RUSTC_WRAPPER: /usr/local/bin/sccache
+          RUSTC_WRAPPER: ${{ env.SCCACHE }}
+          # disable incremental compilation to increase sccache hit rate
+          CARGO_INCREMENTAL: "0"
         with:
           command: build
-          args: --workspace   
+          args: --workspace
+      - name: Check sccache status
+        run: sccache -s    
       - uses: actions-rs/cargo@v1
         env:
-          RUSTC_WRAPPER: /usr/local/bin/sccache
+          RUSTC_WRAPPER: ${{ env.SCCACHE }}
+          # disable incremental compilation to increase sccache hit rate
+          CARGO_INCREMENTAL: "0"
         with:
           command: test
           args: --workspace

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -38,9 +38,45 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          components: rustfmt
           target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         with:
           command: check
           args: --workspace
+
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Intel SGX SDK
+        run: |
+          curl -sSf $INTEL_SGX_SDK > /tmp/intel_sgx_sdk_installer
+          chmod +x /tmp/intel_sgx_sdk_installer
+          echo -e 'no\n/opt/intel' | /tmp/intel_sgx_sdk_installer
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+
+  clippy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Intel SGX SDK
+        run: |
+          curl -sSf $INTEL_SGX_SDK > /tmp/intel_sgx_sdk_installer
+          chmod +x /tmp/intel_sgx_sdk_installer
+          echo -e 'no\n/opt/intel' | /tmp/intel_sgx_sdk_installer
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: clippy
+          target: wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace -- -D warnings

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -27,7 +27,7 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  build:
+  check_and_test:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -42,22 +42,8 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: check
           args: --workspace
-
-  test:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Intel SGX SDK
-        run: |
-          curl -sSf ${INTEL_SGX_SDK} > /tmp/intel_sgx_sdk_installer
-          chmod +x /tmp/intel_sgx_sdk_installer
-          echo -e 'no\n${INTEL_SGX_SDK_INSTALL_PATH}' | /tmp/intel_sgx_sdk_installer
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -196,7 +196,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-18.04
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -217,6 +216,7 @@ jobs:
           components: clippy
           target: wasm32-unknown-unknown
       - uses: actions-rs/cargo@v1
+        continue-on-error: true
         with:
           command: clippy
           args: --workspace -- -D warnings

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -106,6 +106,78 @@ jobs:
           command: test
           args: --workspace
 
+  build_and_test:
+    runs-on: ubuntu-18.04
+    env:
+      SCCACHE_TAR_URL: https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz
+      SCCACHE_CACHE_SIZE: "4G"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache-sccache
+        with:
+          path: |
+            /usr/local/bin/sccache
+          key: ${{ runner.os }}-sccache-${{ env.SCCACHE_TAR_URL }}
+      - uses: actions/cache@v2
+        id: cache-cargo
+        with:
+          # The paths are taken from
+          # https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-cargo-
+      - uses: actions/cache@v2
+        id: cache-sgx
+        with:
+          path: |
+            ${{ env.SGX_SDK_DEST }}/sgxsdk
+          key: ${{ runner.os }}-sgx-${{ env.SGX_SDK_URL }}
+      - uses: actions/cache@v2
+        id: cache-sccache-local-disk
+        with:
+          path: |
+            ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-local-disk
+      - name: Install sccache
+        if: steps.cache-sccache.outputs.cache-hit != 'true'
+        run: |
+          curl -sSf ${SCCACHE_TAR_URL} > /tmp/sccache.tar.gz
+          sudo tar axvf /tmp/sccache.tar.gz --strip-components=1 -C /usr/local/bin --wildcards --no-anchored 'sccache'
+          sudo chmod +x /usr/local/bin/sccache
+          sccache --version
+          sccache -s
+      - name: Install Intel SGX SDK
+        if: steps.cache-sgx.outputs.cache-hit != 'true'
+        run: |
+          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          chmod +x ${SGX_SDK_INSTALLER}
+          echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        env:
+          RUSTC_WRAPPER: /usr/local/bin/sccache
+        with:
+          command: build
+          args: --workspace   
+      - uses: actions-rs/cargo@v1
+        env:
+          RUSTC_WRAPPER: /usr/local/bin/sccache
+        with:
+          command: test
+          args: --workspace
+      - name: Check sccache status
+        run: sccache -s    
+
   clippy:
     runs-on: ubuntu-18.04
     continue-on-error: true

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Intel SGX SDK
         if: steps.cache-sgx.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          curl -LsSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
           chmod +x ${SGX_SDK_INSTALLER}
           echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
       - uses: actions-rs/toolchain@v1
@@ -94,7 +94,7 @@ jobs:
       - name: Install Intel SGX SDK
         if: steps.cache-sgx.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          curl -LsSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
           chmod +x ${SGX_SDK_INSTALLER}
           echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
       - uses: actions-rs/toolchain@v1
@@ -148,7 +148,7 @@ jobs:
       - name: Install sccache
         if: steps.cache-sccache.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${SCCACHE_TAR_URL} > /tmp/sccache.tar.gz
+          curl -LsSf ${SCCACHE_TAR_URL} > /tmp/sccache.tar.gz
           sudo tar axvf /tmp/sccache.tar.gz --strip-components=1 -C /usr/local/bin --wildcards --no-anchored 'sccache'
           sudo chmod +x /usr/local/bin/sccache
           sccache --version
@@ -156,7 +156,7 @@ jobs:
       - name: Install Intel SGX SDK
         if: steps.cache-sgx.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          curl -LsSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
           chmod +x ${SGX_SDK_INSTALLER}
           echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
       - uses: actions-rs/toolchain@v1
@@ -192,7 +192,7 @@ jobs:
       - name: Install Intel SGX SDK
         if: steps.cache-sgx.outputs.cache-hit != 'true'
         run: |
-          curl -sSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
+          curl -LsSf ${SGX_SDK_URL} > ${SGX_SDK_INSTALLER}
           chmod +x ${SGX_SDK_INSTALLER}
           echo -e 'no\n${SGX_SDK_DEST}' | ${SGX_SDK_INSTALLER}
       - uses: actions-rs/toolchain@v1

--- a/geode/builder/src/enclave.rs
+++ b/geode/builder/src/enclave.rs
@@ -35,6 +35,12 @@ pub struct Build {
     local_dependencies: Vec<PathBuf>,
 }
 
+impl Default for enclave::Build {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Build {
     /// Create new build when used standalone
     pub fn new() -> Build {

--- a/geode/builder/src/geode.rs
+++ b/geode/builder/src/geode.rs
@@ -21,6 +21,12 @@ pub struct Build {
     enclaves: Vec<enclave::Build>,
 }
 
+impl Default for geode::Build {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Build {
     pub fn new() -> Build {
         let manifest_dir = Path::new(&CARGO_MANIFEST_DIR.to_string()).to_path_buf();
@@ -54,7 +60,7 @@ impl Build {
     pub fn build(&self) {
         let mut ecall_externs = vec![];
 
-        &self.enclaves.iter().for_each(|e| {
+        self.enclaves.iter().for_each(|e| {
             e.build_crate();
             e.generate_interfaces();
             ecall_externs.extend(e.collect_ecall_extern());

--- a/geode/builder/src/intel.rs
+++ b/geode/builder/src/intel.rs
@@ -14,11 +14,11 @@ use std::str;
 lazy_static! {
     pub static ref SGX_MODE: String = {
         println!("cargo:rerun-if-env-changed=SGX_MODE");
-        env::var("SGX_MODE").unwrap_or(String::from("HW"))
+        env::var("SGX_MODE").unwrap_or_else(|_| String::from("HW"))
     };
     pub static ref SGX_SDK: String = {
         println!("cargo:rerun-if-env-changed=SGX_SDK");
-        env::var("SGX_SDK").unwrap_or(String::from("/opt/intel/sgxsdk"))
+        env::var("SGX_SDK").unwrap_or_else(|_| String::from("/opt/intel/sgxsdk"))
     };
     pub static ref SGX_COMMON_CFLAGS: Vec<&'static str> = {
         let mut args = vec!["-m64"];
@@ -121,10 +121,10 @@ impl Edger8rBuild {
     pub fn execute(&self) {
         copy_file_tree(&self.source_dir, &self.build_dir).unwrap();
 
-        let pic_args = "-cflags -ccopt,-fpie -lflags -runtime-variant,_pic,-ccopt,-pie,-ccopt -lflag -Wl,-z,now -no-links -libs str,unix Edger8r.native".split(" ").filter(|s| !s.is_empty()).collect::<Vec<&str>>();
+        let pic_args = "-cflags -ccopt,-fpie -lflags -runtime-variant,_pic,-ccopt,-pie,-ccopt -lflag -Wl,-z,now -no-links -libs str,unix Edger8r.native".split(' ').filter(|s| !s.is_empty()).collect::<Vec<&str>>();
 
         let args = "-lflag -ccopt -lflag Wl,-z,now -no-links -libs str,unix Edger8r.native"
-            .split(" ")
+            .split(' ')
             .filter(|s| !s.is_empty())
             .collect::<Vec<&str>>();
 
@@ -297,7 +297,7 @@ fn get_ocaml_version() -> (u64, u64) {
     let stdout = str::from_utf8(&output.stdout).unwrap();
 
     let mut splits = stdout
-        .split(".")
+        .split('.')
         .map(|x| x.parse::<u64>())
         .filter_map(|x| x.ok())
         .take(2);

--- a/geode/builder/src/lib.rs
+++ b/geode/builder/src/lib.rs
@@ -57,7 +57,7 @@ fn subprocess(program: &str, args: &[&str], current_dir: Option<&PathBuf>) {
     }
 }
 
-fn generate_extern_proxy(output: &PathBuf, files: &Vec<PathBuf>) {
+fn generate_extern_proxy(output: &PathBuf, files: &[PathBuf]) {
     let out_dir = output.parent().unwrap();
 
     let content = files

--- a/geode/builder/src/teaclave.rs
+++ b/geode/builder/src/teaclave.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use home;
 use lazy_static::lazy_static;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const GIT_REPO: &'static str = "teaclave-sgx-sdk"; // https://github.com/apache/teaclave-sgx-sdk
-const GIT_COMMIT: &'static str = "a6a172e"; // the commit corresponding to tag v1.1.3
-pub const RUST_TOOLCHAIN: &'static str = "nightly-2020-10-25"; // the toolchain version required by teaclave-sgx-sdk
+const GIT_REPO: &str = "teaclave-sgx-sdk"; // https://github.com/apache/teaclave-sgx-sdk
+const GIT_COMMIT: &str = "a6a172e"; // the commit corresponding to tag v1.1.3
+pub const RUST_TOOLCHAIN: &str = "nightly-2020-10-25"; // the toolchain version required by teaclave-sgx-sdk
 
 lazy_static! {
     pub static ref SGX_SDK: String = {

--- a/geode/types/src/eip712.rs
+++ b/geode/types/src/eip712.rs
@@ -78,7 +78,7 @@ impl EIP712Domain {
         EIP712Domain {
             name: name.to_owned(),
             version: version.to_owned(),
-            chainId: chainId,
+            chainId,
             verifyingContract: contract,
         }
     }
@@ -162,10 +162,10 @@ where
         message: T,
     ) -> Self {
         EIP712Msg {
-            types: types,
-            domain: domain,
+            types,
+            domain,
             primaryType: primaryType.to_owned(),
-            message: message,
+            message,
         }
     }
 

--- a/geode/types/src/secp256k1.rs
+++ b/geode/types/src/secp256k1.rs
@@ -88,7 +88,7 @@ impl Secp256k1RecoverableSignature {
         data[..32].copy_from_slice(&self.r);
         data[32..64].copy_from_slice(&self.s);
         data[64] = self.v;
-        format!("0x{}", hex::encode(&data)).to_owned()
+        format!("0x{}", hex::encode(&data))
     }
 }
 
@@ -102,8 +102,8 @@ impl From<rust_secp256k1::recovery::RecoverableSignature> for Secp256k1Recoverab
         s.copy_from_slice(&sig[32..]);
         Secp256k1RecoverableSignature {
             v: recid.to_i32().try_into().unwrap(),
-            r: r,
-            s: s,
+            r,
+            s,
         }
     }
 }
@@ -206,7 +206,7 @@ impl From<rust_secp256k1::Signature> for Secp256k1Signature {
         r.copy_from_slice(&serialized_bytes[..32]);
         s.copy_from_slice(&serialized_bytes[32..]);
 
-        Secp256k1Signature { r: r, s: s }
+        Secp256k1Signature { r, s }
     }
 }
 
@@ -223,23 +223,23 @@ impl From<Secp256k1Signature> for rust_secp256k1::Signature {
 
 impl fmt::Display for Secp256k1PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Secp256k1PrivateKey\n").unwrap();
-        write!(f, "r: {}\n", hex::encode(self.r))
+        writeln!(f, "Secp256k1PrivateKey").unwrap();
+        writeln!(f, "r: {}", hex::encode(self.r))
     }
 }
 
 impl fmt::Display for Secp256k1PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Secp256k1PublicKey\n").unwrap();
-        write!(f, "gx: {}\n", hex::encode(self.gx)).unwrap();
-        write!(f, "gy: {}\n", hex::encode(self.gy))
+        writeln!(f, "Secp256k1PublicKey").unwrap();
+        writeln!(f, "gx: {}", hex::encode(self.gx)).unwrap();
+        writeln!(f, "gy: {}", hex::encode(self.gy))
     }
 }
 
 impl fmt::Display for Secp256k1Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Secp256k1Signature\n").unwrap();
-        write!(f, "r: {}\n", hex::encode(self.r)).unwrap();
-        write!(f, "s: {}\n", hex::encode(self.s))
+        writeln!(f, "Secp256k1Signature").unwrap();
+        writeln!(f, "r: {}", hex::encode(self.r)).unwrap();
+        writeln!(f, "s: {}", hex::encode(self.s))
     }
 }

--- a/geode/types/src/secp256r1.rs
+++ b/geode/types/src/secp256r1.rs
@@ -256,23 +256,23 @@ impl From<Secp256r1Signature> for sgx_ec256_signature_t {
 
 impl fmt::Display for Secp256r1PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Secp256r1PrivateKey\n").unwrap();
-        write!(f, "r: {}\n", hex::encode(self.r))
+        writeln!(f, "Secp256r1PrivateKey").unwrap();
+        writeln!(f, "r: {}", hex::encode(self.r))
     }
 }
 
 impl fmt::Display for Secp256r1PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Secp256r1PublicKey\n").unwrap();
-        write!(f, "gx: {}\n", hex::encode(self.gx)).unwrap();
-        write!(f, "gy: {}\n", hex::encode(self.gy))
+        writeln!(f, "Secp256r1PublicKey").unwrap();
+        writeln!(f, "gx: {}", hex::encode(self.gx)).unwrap();
+        writeln!(f, "gy: {}", hex::encode(self.gy))
     }
 }
 
 impl fmt::Display for Secp256r1Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Secp256r1Signature\n").unwrap();
-        write!(f, "x: {}\n", hex::encode(self.x)).unwrap();
-        write!(f, "y: {}\n", hex::encode(self.y))
+        writeln!(f, "Secp256r1Signature").unwrap();
+        writeln!(f, "x: {}", hex::encode(self.x)).unwrap();
+        writeln!(f, "y: {}", hex::encode(self.y))
     }
 }

--- a/geode/types/src/sr25519.rs
+++ b/geode/types/src/sr25519.rs
@@ -157,18 +157,18 @@ impl fmt::Debug for Sr25519Signature {
 
 impl fmt::Display for Sr25519PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Sr25519PrivateKey\n").unwrap();
-        write!(f, "secret: {}\n", hex::encode(self.secret)).unwrap();
-        write!(f, "nonce : {}\n", hex::encode(self.nonce))
+        writeln!(f, "Sr25519PrivateKey").unwrap();
+        writeln!(f, "secret: {}", hex::encode(self.secret)).unwrap();
+        writeln!(f, "nonce : {}", hex::encode(self.nonce))
     }
 }
 
 impl fmt::Display for Sr25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Sr25519PublicKey\n").unwrap();
-        write!(
+        writeln!(f, "Sr25519PublicKey").unwrap();
+        writeln!(
             f,
-            "compressed_point: {}\n",
+            "compressed_point: {}",
             hex::encode(self.compressed_point)
         )
     }

--- a/geode/types/src/utils.rs
+++ b/geode/types/src/utils.rs
@@ -80,7 +80,7 @@ pub fn parse_string_h256(h256_str: &str) -> H256 {
 pub fn encode_string_h256(h256: &H256) -> String {
     // here we just make use of the display functionality of H256
     // the debug string prints in full form (hex)
-    format!("{:?}", h256).to_owned()
+    format!("{:?}", h256)
 }
 
 pub fn eth_secp256k1_to_accountid(pubkey: &Secp256k1PublicKey) -> Address {

--- a/geode/types/src/witness.rs
+++ b/geode/types/src/witness.rs
@@ -116,9 +116,7 @@ impl Vote {
 
         let domain = EIP712Domain::new("Witness", "0.1.0", chainId, verifyingContract);
 
-        let msg = EIP712Msg::new(types, domain, "Vote", self.clone());
-
-        msg
+        EIP712Msg::new(types, domain, "Vote", self.clone())
     }
 }
 

--- a/node/pallets/fulfillment/src/mock.rs
+++ b/node/pallets/fulfillment/src/mock.rs
@@ -1,21 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Config, Module};
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
 use frame_system as system;
-use frame_system::limits::{BlockLength, BlockWeights};
 use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
-};
+use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 impl_outer_origin! {
     pub enum Origin for Test {}
 }
-
-// Configure a mock runtime to test the pallet.
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
@@ -52,12 +44,8 @@ impl frame_system::Config for Test {
     type SS58Prefix = SS58Prefix;
 }
 
-pub type System = frame_system::Module<Test>;
-pub type Geode = Module<Test>;
-
-// Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    let mut t = system::GenesisConfig::default()
+    let t = system::GenesisConfig::default()
         .build_storage::<Test>()
         .unwrap();
     let mut ext = sp_io::TestExternalities::new(t);

--- a/node/pallets/fulfillment/src/tests.rs
+++ b/node/pallets/fulfillment/src/tests.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{mock::*, Error};
-use frame_support::{assert_noop, assert_ok};
+use crate::mock::*;
 
 #[test]
 fn is_work() {

--- a/node/pallets/marketplace/src/mock.rs
+++ b/node/pallets/marketplace/src/mock.rs
@@ -4,14 +4,10 @@ use crate::{Config, Module};
 use frame_support::{
     impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, weights::Weight,
 };
-use frame_system::{self as system, EventRecord, Phase};
+use frame_system as system;
 use pallet_balances as balances;
 use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
-};
+use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 //use crate as marketplace;
 use crate::Event;
 use pallet_stake as stake;
@@ -20,8 +16,7 @@ use sp_std::prelude::*;
 mod marketplace {
     pub use crate::Event;
 }
-use frame_system::limits::{BlockLength, BlockWeights};
-use fulfillment::{Event as geodeEvent, GeodeOf, GeodeProperties, GeodeState};
+use fulfillment::Event as geodeEvent;
 
 pub type AccountId = u64;
 
@@ -44,8 +39,6 @@ impl_outer_dispatch! {
         marketplace::Marketplace,
     }
 }
-
-// Configure a mock runtime to test the pallet.
 
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
@@ -118,7 +111,6 @@ pub type Marketplace = Module<Test>;
 pub type Geode = fulfillment::Module<Test>;
 pub type Stake = pallet_stake::Module<Test>;
 
-// Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()

--- a/node/pallets/marketplace/src/tests.rs
+++ b/node/pallets/marketplace/src/tests.rs
@@ -1,18 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::mock::TestEvent;
+use crate::mock::*;
 use crate::sp_api_hidden_includes_decl_storage::hidden_include::traits::OnFinalize;
 use crate::RawEvent;
-use crate::{mock::*, Error};
-use frame_support::{
-    assert_err, assert_err_ignore_postinfo, assert_noop, assert_ok,
-    dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable},
-    impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, storage,
-    traits::Filter,
-    weights::{Pays, Weight},
-};
+use frame_support::{assert_err, assert_ok};
 use fulfillment::{GeodeOf, GeodeProperties, GeodeState, RawEvent as geodeRawEvent};
-use sp_core::H256;
 use sp_std::prelude::*;
 
 fn create_geode_device<T: fulfillment::Config>(owner: T::AccountId) -> GeodeOf<T> {
@@ -49,7 +42,7 @@ fn last_event() -> TestEvent {
 
 fn get_orderid_from_event() -> AccountId {
     match marketpalce_events().last().unwrap() {
-        RawEvent::PutOrder(x, y) => {
+        RawEvent::PutOrder(_x, y) => {
             return *y;
         }
         _ => {
@@ -137,7 +130,7 @@ fn install_test() {
         assert_eq!(Stake::users(1).total, 50);
         assert_eq!(Stake::users(1).active, 50);
 
-        let attestation = vec![0u8];
+        let _attestation = vec![0u8];
         let device = create_geode_device::<Test>(1);
         assert_ok!(Geode::provider_register_geode(Origin::signed(1), device));
         let event = last_event();
@@ -198,7 +191,7 @@ fn order_test() {
         );
         //TODO:: Registed -> Attested     attestors only 2
 
-        println!("{:?}", geoid);
+        println!("{}", geoid);
         assert_ok!(Marketplace::put_order(Origin::signed(1), geoid, 5, 5));
         let orderid = get_orderid_from_event();
 

--- a/node/pallets/stake/src/mock.rs
+++ b/node/pallets/stake/src/mock.rs
@@ -4,7 +4,7 @@ use crate::{Config, Module};
 use frame_support::{
     impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, weights::Weight,
 };
-use frame_system::{self as system, EventRecord, Phase};
+use frame_system as system;
 use pallet_balances as balances;
 use sp_core::H256;
 use sp_runtime::{

--- a/node/pallets/stake/src/mock.rs
+++ b/node/pallets/stake/src/mock.rs
@@ -7,14 +7,7 @@ use frame_support::{
 use frame_system as system;
 use pallet_balances as balances;
 use sp_core::H256;
-use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
-};
-//use crate as marketplace;
-use crate::Event;
-use frame_system::limits::{BlockLength, BlockWeights};
+use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 use crate as stake;
 
@@ -98,7 +91,6 @@ pub type System = frame_system::Module<Test>;
 pub type Balances = balances::Module<Test>;
 pub type Stake = Module<Test>;
 
-// Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()
@@ -111,18 +103,4 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut ext = sp_io::TestExternalities::new(t);
     ext.execute_with(|| System::set_block_number(1));
     ext
-}
-
-pub(crate) fn marketpalce_events() -> Vec<Event<Test>> {
-    System::events()
-        .into_iter()
-        .map(|r| r.event)
-        .filter_map(|e| {
-            if let TestEvent::stake(inner) = e {
-                Some(inner)
-            } else {
-                None
-            }
-        })
-        .collect()
 }

--- a/node/pallets/stake/src/offline.rs
+++ b/node/pallets/stake/src/offline.rs
@@ -44,7 +44,7 @@ impl<Offender: Clone> AutomataOffence<Offender> for GeodeOffence<Offender> {
     type SpecialId = u64;
 
     fn kind(&self) -> Kind {
-        return Self::ID;
+        Self::ID
     }
 
     fn offender(&self) -> Offender {

--- a/node/pallets/stake/src/tests.rs
+++ b/node/pallets/stake/src/tests.rs
@@ -1,23 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::mock::TestEvent;
-use crate::RawEvent;
-use crate::{mock::*, Error};
-use frame_support::{
-    assert_err, assert_err_ignore_postinfo, assert_noop, assert_ok,
-    dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable},
-    impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, storage,
-    traits::Filter,
-    weights::{Pays, Weight},
-};
-use sp_core::H256;
-
-fn last_event() -> TestEvent {
-    System::events()
-        .pop()
-        .map(|e| e.event)
-        .expect("Event expected")
-}
+use crate::mock::*;
 
 #[test]
 fn should_slash_work_test() {


### PR DESCRIPTION
Improve the build time for the rust workflow with several strategies:

1. Break a long running job into several parallel jobs. They are **Format**, **Build and Test** and **Clippy**
2. Use [sccache](https://github.com/mozilla/sccache) together with Github [cache action](https://github.com/actions/cache) to increase cache hit rate while keeping the cache usage low (there's a 5G limit shared by all jobs in a repository)

There are some statistics:

**Full build without any caching between builds**
1. `cargo fmt --all -- --check` takes 1m 8s
2. `cargo check --workspace` takes 21m 58s
3. `cargo build --workspace` takes 28m 21s
4. `cargo test --workspace`takes 33m 25s
5. `cargo clippy --workspace -- -D warnings`: N/A 
6.  `cargo check --workspace` followed by `cargo test --workspace` takes 24m 50s and 10m 50s respectively.

**With cache (sccache)**
1. `cargo check --workspace` followed by `cargo test --workspace` takes ~10m and ~6m respectively.

And the current cache usage for sccache is limited to 1G through `SCCACHE_CACHE_SIZE`, making it possible to have at least have 4 or 5 different copies of sccache for different pull requests.

Note that the **Clippy** job has `continue-on-error` flag on, this makes it only suggestions to developers as we are still evaluating it. 