### PR TITLE
Speed up CI docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,8 +17,6 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Create buildx cache directory
-        run: mkdir -p /tmp/.buildx-cache
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -40,9 +38,9 @@ jobs:
             echo "${DOCKER_REPO}:latest" >> $GITHUB_ENV
           fi
           echo 'EOF' >> $GITHUB_ENV
-      - name: Build and push
-        id: docker_build
+      - name: Build with cache and push images
         uses: docker/build-push-action@v2
+        id: docker_build
         with:
           push: true
           cache-from: |
@@ -50,9 +48,17 @@ jobs:
             type=local,src=/tmp/.buildx-cache
           cache-to: |
             type=local,dest=/tmp/.buildx-cache-new,mode=max
-            type=registry,ref=${{ env.DOCKER_REPO }}:builder,mode=max
           tags: |
             ${{ env.DOCKER_TAGS }}
+      - name: Update registry cache
+        uses: docker/build-push-action@v2
+        if: github.ref == 'refs/heads/main'
+        with:
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_REPO }}:builder
+            type=local,src=/tmp/.buildx-cache
+          cache-to: |
+            type=registry,ref=${{ env.DOCKER_REPO }}:builder,mode=max
       - # FIXME: a workaround before these issues got fixed
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,7 +82,7 @@ jobs:
         env:
           KEEP_STORAGE: "1073741824" # this is 1GB
         run: |
-          docker buildx --builder ${BUILDX_BUILDER} du --verbose
+          docker buildx --builder ${BUILDX_BUILDER} du
           docker buildx --builder ${BUILDX_BUILDER} prune --force --keep-storage ${KEEP_STORAGE}
           docker run --rm --volumes-from "${BUILDX_BUILDER_CONTAINER}" \
             -v /tmp/buildkit-cache:/backup \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,6 +17,13 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
@@ -36,9 +43,20 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          cache-from: ${{ env.DOCKER_REPO }}:latest
-          cache-to: type=inline,mode=max
+          cache-from: |
+            type=registry,ref=${{ env.DOCKER_REPO }}:builder
+            type=local,src=/tmp/.buildx-cache
+          cache-to: |
+            type=local,dest=/tmp/.buildx-cache-new,mode=max
+            type=registry,ref=${{ env.DOCKER_REPO }}:builder,mode=max
           tags: |
             ${{ env.DOCKER_TAGS }}
+      - # FIXME: a workaround before these issues got fixed
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,23 +13,30 @@ jobs:
     env:
       DOCKER_REPO: atactr/automata
     steps:
+      - uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
+        id: docker-builder
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
+      - name: Cache Buildx
         uses: actions/cache@v2
+        id: buildx-cache
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-buildx-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-buildx-
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Generate tags
+      - name: Prepare Environment Variables
+        env:
+          BUILDX_BUILDER: ${{ steps.docker-builder.outputs.name }}
+          BUILDX_BUILDER_CONTAINER: buildx_buildkit_${{ steps.docker-builder.outputs.name }}0
         run: |
           echo 'DOCKER_TAGS<<EOF' >> $GITHUB_ENV
           echo "${DOCKER_REPO}:${GITHUB_SHA::8}" >> $GITHUB_ENV
@@ -38,33 +45,48 @@ jobs:
             echo "${DOCKER_REPO}:latest" >> $GITHUB_ENV
           fi
           echo 'EOF' >> $GITHUB_ENV
+      - name: Restore buildx cache
+        # Handle cache mount in buildx
+        # See https://github.com/docker/buildx/issues/156#issuecomment-537492942
+        if: steps.buildx-cache.outputs.cache-hit == 'true'
+        run: |
+          docker buildx stop --builder "${BUILDX_BUILDER}"
+          docker run --rm --volumes-from "${BUILDX_BUILDER_CONTAINER}" \
+            -v /tmp/buildkit-cache:/backup \
+            alpine /bin/sh -c "cd / && tar xf /backup/backup.tar.gz"
       - name: Build with cache and push images
         uses: docker/build-push-action@v2
         id: docker_build
         with:
+          builder: ${{ steps.docker-builder.outputs.name }}
           push: true
           cache-from: |
             type=registry,ref=${{ env.DOCKER_REPO }}:builder
-            type=local,src=/tmp/.buildx-cache
           cache-to: |
-            type=local,dest=/tmp/.buildx-cache-new,mode=max
+            type=registry,dest=/tmp/buildx-cache-cross-step,mode=max
           tags: |
             ${{ env.DOCKER_TAGS }}
       - name: Update registry cache
         uses: docker/build-push-action@v2
         if: github.ref == 'refs/heads/main'
         with:
+          builder: ${{ steps.docker-builder.outputs.name }}
           cache-from: |
             type=registry,ref=${{ env.DOCKER_REPO }}:builder
-            type=local,src=/tmp/.buildx-cache
+            type=local,src=/tmp/buildx-cache-cross-step
           cache-to: |
             type=registry,ref=${{ env.DOCKER_REPO }}:builder,mode=max
-      - # FIXME: a workaround before these issues got fixed
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
+      - name: Backup buildx cache
+        # Handle cache mount in buildx
+        # See https://github.com/docker/buildx/issues/156#issuecomment-537492942
+        env:
+          KEEP_STORAGE: "1073741824" # this is 1GB
         run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          docker buildx --builder ${BUILDX_BUILDER} du --verbose
+          docker buildx --builder ${BUILDX_BUILDER} prune --force --keep-storage ${KEEP_STORAGE}
+          docker run --rm --volumes-from "${BUILDX_BUILDER_CONTAINER}" \
+            -v /tmp/buildkit-cache:/backup \
+            alpine /bin/sh -c "cd / && tar cf /backup/backup.tar.gz /var/lib/buildkit"
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Create buildx cache directory
+        run: mkdir -p /tmp/.buildx-cache
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,9 +34,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Prepare Environment Variables
-        env:
-          BUILDX_BUILDER: ${{ steps.docker-builder.outputs.name }}
-          BUILDX_BUILDER_CONTAINER: buildx_buildkit_${{ steps.docker-builder.outputs.name }}0
         run: |
           echo 'DOCKER_TAGS<<EOF' >> $GITHUB_ENV
           echo "${DOCKER_REPO}:${GITHUB_SHA::8}" >> $GITHUB_ENV
@@ -45,6 +42,8 @@ jobs:
             echo "${DOCKER_REPO}:latest" >> $GITHUB_ENV
           fi
           echo 'EOF' >> $GITHUB_ENV
+          echo "BUILDX_BUILDER=${{ steps.docker-builder.outputs.name }}" >> $GITHUB_ENV
+          echo "BUILDX_BUILDER_CONTAINER=buildx_buildkit_${{ steps.docker-builder.outputs.name }}0" >> $GITHUB_ENV
       - name: Restore buildx cache
         # Handle cache mount in buildx
         # See https://github.com/docker/buildx/issues/156#issuecomment-537492942
@@ -52,8 +51,10 @@ jobs:
         run: |
           docker buildx stop --builder "${BUILDX_BUILDER}"
           docker run --rm --volumes-from "${BUILDX_BUILDER_CONTAINER}" \
-            -v /tmp/buildkit-cache:/backup \
-            alpine /bin/sh -c "cd / && tar xf /backup/backup.tar.gz"
+            -v /tmp/buildx-cache:/backup \
+            alpine:3.10 /bin/sh -c "cd / && tar xf /backup/backup.tar.gz"
+          docker buildx inspect --builder "${BUILDX_BUILDER}" --bootstrap
+          docker buildx --builder "${BUILDX_BUILDER}" du --verbose
       - name: Build with cache and push images
         uses: docker/build-push-action@v2
         id: docker_build
@@ -63,7 +64,7 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.DOCKER_REPO }}:builder
           cache-to: |
-            type=registry,dest=/tmp/buildx-cache-cross-step,mode=max
+            type=local,dest=/tmp/buildx-cache-cross-step,mode=max
           tags: |
             ${{ env.DOCKER_TAGS }}
       - name: Update registry cache
@@ -82,11 +83,19 @@ jobs:
         env:
           KEEP_STORAGE: "1073741824" # this is 1GB
         run: |
-          docker buildx --builder ${BUILDX_BUILDER} du
-          docker buildx --builder ${BUILDX_BUILDER} prune --force --keep-storage ${KEEP_STORAGE}
+          echo "Before pruning"
+          docker buildx --builder "${BUILDX_BUILDER}" du --verbose
+          echo "Start pruning"
+          docker buildx --builder "${BUILDX_BUILDER}" prune --force --filter type=frontend
+          docker buildx --builder "${BUILDX_BUILDER}" prune --force --filter type=regular
+          docker buildx --builder "${BUILDX_BUILDER}" prune --force --filter type=source.local 
+          docker buildx --builder "${BUILDX_BUILDER}" prune --force --keep-storage ${KEEP_STORAGE}
+          echo "After pruning"
+          docker buildx --builder "${BUILDX_BUILDER}" du --verbose
+          echo "Backup buildx cache"
           docker run --rm --volumes-from "${BUILDX_BUILDER_CONTAINER}" \
-            -v /tmp/buildkit-cache:/backup \
-            alpine /bin/sh -c "cd / && tar cf /backup/backup.tar.gz /var/lib/buildkit"
+            -v /tmp/buildx-cache:/backup \
+            alpine:3.10 /bin/sh -c "cd / && tar cf /backup/backup.tar.gz /var/lib/buildkit"
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo 'DOCKER_TAGS<<EOF' >> $GITHUB_ENV
           echo "${DOCKER_REPO}:${GITHUB_SHA::8}" >> $GITHUB_ENV
-          if [ "${GITHUB_REF}" = "ref/heads/main" ]
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]
           then
             echo "${DOCKER_REPO}:latest" >> $GITHUB_ENV
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 
-
 ## The default members are packages with dependencies that are trivial to install
 ##
 ## These members will be selected when running `cargo check` or `cargo build` directly
@@ -31,7 +30,6 @@ members = [
     "geode/macros",
     "geode/sgx-ra",
 ]
-
 
 [profile.release]
 panic = 'unwind'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,29 @@ ARG PROFILE=release
 ARG TOOLCHAIN=nightly-2020-10-25
 
 RUN apt-get update && \
-	apt-get install -y --no-install-recommends cmake clang
+	apt-get install -y --no-install-recommends cmake clang curl
 
 RUN rustup toolchain install ${TOOLCHAIN} && \
     rustup default ${TOOLCHAIN} && \
     rustup target add wasm32-unknown-unknown --toolchain ${TOOLCHAIN}
 
+ARG SCCACHE_TAR_URL=https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz
+
+RUN curl -LsSf ${SCCACHE_TAR_URL} > /tmp/sccache.tar.gz && \
+	tar axvf /tmp/sccache.tar.gz --strip-components=1 -C /usr/local/bin --wildcards --no-anchored 'sccache' && \
+	chmod +x /usr/local/bin/sccache && \
+	sccache --version && \
+	rm -rf /tmp/sccache.tar.gz
+
+ENV RUSTC_WRAPPER=/usr/local/bin/sccache
+ENV CARGO_INCREMENTAL=0
+ENV SCCACHE_CACHE_SIZE=1G
+
 WORKDIR /automata
 
 COPY . /automata
 
-RUN --mount=type=cache,target=/automata/target/ \
+RUN --mount=type=cache,target=/root/.cache/sccache \
 	--mount=type=cache,target=/usr/local/cargo/registry/index \
 	--mount=type=cache,target=/usr/local/cargo/registry/cache \
 	--mount=type=cache,target=/usr/local/cargo/git/db \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Rust](../../workflows/Rust/badge.svg)](../../actions?query=workflow%3ARust)
+[![Rust](../../workflows/Rust/badge.svg)](../../actions?query=workflow%3ARust+branch%3Amain) [![Docker](../../workflows/Docker/badge.svg)](../../actions?query=workflow%3ADocker+branch%3Amain)
 # Automata
 
 ## Build

--- a/geode/crypto/src/aes128.rs
+++ b/geode/crypto/src/aes128.rs
@@ -20,7 +20,7 @@ use std::vec::Vec;
 
 pub fn aes128cmac_mac(p_key: &Aes128Key, p_data: &[u8]) -> Result<Aes128Mac, CryptoError> {
     match rsgx_rijndael128_cmac_slice(&p_key.key, p_data) {
-        Ok(mac) => Ok(Aes128Mac { mac: mac }),
+        Ok(mac) => Ok(Aes128Mac { mac }),
         Err(s) => Err(CryptoError::SgxError(s.from_key(), format!("{}", s))),
     }
 }
@@ -52,9 +52,9 @@ pub fn aes128gcm_encrypt(
     };
 
     Ok(Aes128EncryptedMsg {
-        iv: iv,
-        mac: Aes128Mac { mac: mac },
-        cipher: cipher,
+        iv,
+        mac: Aes128Mac { mac },
+        cipher,
     })
 }
 

--- a/geode/crypto/src/enclave.rs
+++ b/geode/crypto/src/enclave.rs
@@ -15,5 +15,5 @@ pub fn enclave_get_sk_key(ra_context: sgx_ra_context_t) -> Result<Aes128Key, Cry
             &mut key
         ))?;
     };
-    Ok(Aes128Key { key: key })
+    Ok(Aes128Key { key })
 }

--- a/geode/crypto/src/secp256k1.rs
+++ b/geode/crypto/src/secp256k1.rs
@@ -63,10 +63,7 @@ pub fn secp256k1_sign_msg<T: Serialize>(
 ) -> Result<Secp256k1SignedMsg<T>, CryptoError> {
     let msg_bytes = serde_json::to_vec(&msg).unwrap();
     let signature = secp256k1_sign_bytes(prvkey, &msg_bytes)?;
-    Ok(Secp256k1SignedMsg {
-        msg,
-        signature,
-    })
+    Ok(Secp256k1SignedMsg { msg, signature })
 }
 
 pub fn secp256k1_sign_bytes(

--- a/geode/crypto/src/secp256k1.rs
+++ b/geode/crypto/src/secp256k1.rs
@@ -64,8 +64,8 @@ pub fn secp256k1_sign_msg<T: Serialize>(
     let msg_bytes = serde_json::to_vec(&msg).unwrap();
     let signature = secp256k1_sign_bytes(prvkey, &msg_bytes)?;
     Ok(Secp256k1SignedMsg {
-        msg: msg,
-        signature: signature,
+        msg,
+        signature,
     })
 }
 
@@ -167,7 +167,7 @@ pub fn secp256k1_eip712_sign<T: Serialize + EIP712>(
     let data = msg.eip712_encode_msg();
     let signature = secp256k1_rec_sign_bytes(prvkey, &data)?;
     let result = EIP712SignedMsg {
-        msg: msg,
+        msg,
         v: signature.v + 27,
         r: signature.r.into(),
         s: signature.s.into(),

--- a/geode/crypto/src/secp256r1.rs
+++ b/geode/crypto/src/secp256r1.rs
@@ -78,8 +78,8 @@ pub fn secp256r1_sign_msg<T: Serialize>(
     let signature = secp256r1_sign_bytes(prvkey, &msg_bytes)?;
 
     Ok(Secp256r1SignedMsg::<T> {
-        msg: msg,
-        signature: signature,
+        msg,
+        signature,
     })
 }
 

--- a/geode/crypto/src/secp256r1.rs
+++ b/geode/crypto/src/secp256r1.rs
@@ -77,10 +77,7 @@ pub fn secp256r1_sign_msg<T: Serialize>(
     let msg_bytes = serde_json::to_vec(&msg).unwrap();
     let signature = secp256r1_sign_bytes(prvkey, &msg_bytes)?;
 
-    Ok(Secp256r1SignedMsg::<T> {
-        msg,
-        signature,
-    })
+    Ok(Secp256r1SignedMsg::<T> { msg, signature })
 }
 
 pub fn secp256r1_sign_bytes(

--- a/geode/crypto/src/sr25519.rs
+++ b/geode/crypto/src/sr25519.rs
@@ -47,10 +47,7 @@ pub fn sr25519_sign_msg<T: Serialize>(
 ) -> Result<Sr25519SignedMsg<T>, CryptoError> {
     let msg_bytes = serde_json::to_vec(&msg).unwrap();
     let signature = sr25519_sign_bytes(prvkey, &msg_bytes)?;
-    Ok(Sr25519SignedMsg {
-        msg,
-        signature,
-    })
+    Ok(Sr25519SignedMsg { msg, signature })
 }
 
 pub fn sr25519_sign_bytes(

--- a/geode/crypto/src/sr25519.rs
+++ b/geode/crypto/src/sr25519.rs
@@ -48,8 +48,8 @@ pub fn sr25519_sign_msg<T: Serialize>(
     let msg_bytes = serde_json::to_vec(&msg).unwrap();
     let signature = sr25519_sign_bytes(prvkey, &msg_bytes)?;
     Ok(Sr25519SignedMsg {
-        msg: msg,
-        signature: signature,
+        msg,
+        signature,
     })
 }
 

--- a/node/pallets/fulfillment/src/property.rs
+++ b/node/pallets/fulfillment/src/property.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use serde_json::Value;
 use sp_runtime::RuntimeDebug;
-use sp_std::{prelude::*, str::FromStr};
+use sp_std::prelude::*;
+#[cfg(feature = "std")]
+use sp_std::str::FromStr;
 
 pub type PropName = Vec<u8>;
 pub type PropValue = Vec<u8>;

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -38,16 +38,18 @@ else
     CACHE_FROM="type=registry,ref=atactr/automata:latest"
 fi
 
+BUILDER=automata-docker-builder
+
 if docker buildx >/dev/null 2>&1
 then
-    ## Create automata-docker-builder instance for buildx
-    docker buildx inspect automata-docker-builder >/dev/null 2>&1 || docker buildx create --driver docker-container --name automata-docker-builder --use
+    ## Create builder instance for buildx
+    docker buildx inspect "${BUILDER}" >/dev/null 2>&1 || docker buildx create --driver docker-container --name "${BUILDER}" --use
     ## Build with buildx to allow cross-build cache
-    docker buildx build --cache-from="${CACHE_FROM}" --cache-to="type=local,mode=max,dest=${CACHE_DIR}" --tag "${TAG}" --load .
+    docker buildx build --builder "${BUILDER}" --cache-from="${CACHE_FROM}" --cache-to="type=local,mode=max,dest=${CACHE_DIR}" --tag "${TAG}" --load .
 else
-    ## No docker buildx plugin found, fallback to default docker build command without any cache
+    ## No docker buildx plugin found, fallback to default docker build command
     ##
-    ## If you need faster build next time, install docker buildx: https://github.com/docker/buildx#installing
+    ## Use DOCKER_BUILDKIT environment variable for backward compatiblity.
     DOCKER_BUILDKIT=1 docker build --tag "${TAG}" .
 fi
 


### PR DESCRIPTION
Previously, the CI docker build takes over 50 minutes because of the limited hardware resources from the [official runner spec](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources): 2-core CPU, 7 GB of RAM memory. 

This pull request takes advantage of [`--mount=type=cache`](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache) to cache the sccache directory (dominant) and cargo registry directories during the `builder` stage.  (cargo target folder is not cached due to large size).

https://github.com/automata-network/automata/blob/6ca74d3a0d134d24c8e0f4974a2ff5459900da00/Dockerfile#L31-L36

The above strategy works fine on local machine where the `buildx` builder is reused and the cached content from `--mount=type=cache` can be reused across different builds. (See [`scripts/docker-build.sh`](https://github.com/automata-network/automata/blob/speedup-docker-build/scripts/docker-build.sh)).

In CI environment like Github Action, the `buildx` builder is recreated every time so some [workaround](https://github.com/docker/buildx/issues/156#issuecomment-537492942) is needed in order to persist the cached content from `--mount=type=cache`  different workflow runs.

Restore 
https://github.com/automata-network/automata/blob/6ca74d3a0d134d24c8e0f4974a2ff5459900da00/.github/workflows/docker.yaml#L47-L57

Backup
https://github.com/automata-network/automata/blob/6ca74d3a0d134d24c8e0f4974a2ff5459900da00/.github/workflows/docker.yaml#L80-L98

As a result, now the CI docker build takes around [23 minutes](https://github.com/automata-network/automata/actions/runs/609655744) to complete when most of the cache is valid. If there's some major code change,  the time spent should be in the range of 23 to 50 minutes.

**Other fixes**
* add new badge for Docker workflow in README.
* address the issue where `latest` image is not pushed when `main` branch is updated.
* fix some clippy warnings