### PR TITLE
Adding functions for pallet-geode

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -280,7 +280,7 @@ fn testnet_genesis(
 
     if let Some(ethereum_accounts) = ethereum_accounts {
         ethereum_accounts.iter().for_each(|x| {
-            if !endowed_accounts.contains(&x) {
+            if !endowed_accounts.contains(x) {
                 endowed_accounts.push(x.clone())
             }
         });

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -129,14 +129,14 @@ pub fn new_partial(
     );
 
     let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(
-        frontier_block_import.clone(),
+        frontier_block_import,
         client.clone(),
     );
 
     let import_queue = sc_consensus_aura::import_queue::<_, _, _, AuraPair, _, _>(
         sc_consensus_aura::slot_duration(&*client)?,
         aura_block_import.clone(),
-        Some(Box::new(grandpa_block_import.clone())),
+        Some(Box::new(grandpa_block_import)),
         client.clone(),
         inherent_data_providers.clone(),
         &task_manager.spawn_handle(),
@@ -156,7 +156,7 @@ pub fn new_partial(
         other: (
             (aura_block_import, grandpa_link),
             pending_transactions,
-            frontier_backend.clone(),
+            frontier_backend,
         ),
     })
 }

--- a/pallets/attestor/src/lib.rs
+++ b/pallets/attestor/src/lib.rs
@@ -118,7 +118,7 @@ pub mod pallet {
                 pubkey,
                 geodes: BTreeSet::new(),
             };
-            <Attestors<T>>::insert(who.clone(), attestor);
+            <Attestors<T>>::insert(&who, attestor);
             Self::deposit_event(Event::AttestorRegister(who));
             Ok(().into())
         }

--- a/pallets/liveness/src/lib.rs
+++ b/pallets/liveness/src/lib.rs
@@ -11,7 +11,7 @@ mod tests;
 #[frame_support::pallet]
 pub mod pallet {
     use core::convert::{TryFrom, TryInto};
-    use frame_support::ensure;
+    use frame_support::{debug::native::debug, ensure};
     use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
     use frame_system::pallet_prelude::*;
     use primitives::BlockNumber;
@@ -25,6 +25,7 @@ pub mod pallet {
     pub const ATTESTOR_REQUIRE: usize = 1;
     pub const REPORT_APPROVAL_RATIO: Percent = Percent::from_percent(50);
     pub const REPORT_EXPIRY_BLOCK_NUMBER: BlockNumber = 10;
+    pub const ATTESTATION_EXPIRY_BLOCK_NUMBER: BlockNumber = 30;
 
     /// Geode state
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -119,11 +120,14 @@ pub mod pallet {
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-        /// At every block, check if a misconduct report has expired or not,
+        /// 1. At every block, check if a misconduct report has expired or not,
         /// if expired, clean the report.
-        fn on_finalize(block_number: T::BlockNumber) {
+        /// 2. At every block, check if any geode haven't get attested after an expiring block,
+        /// if expired, clean the report.
+        fn on_initialize(block_number: T::BlockNumber) -> Weight {
             match TryInto::<BlockNumber>::try_into(block_number) {
                 Ok(now) => {
+                    // clean expired reports
                     let mut expired = Vec::<(T::AccountId, u8)>::new();
                     <Reports<T>>::iter()
                         .map(|(key, report)| {
@@ -135,9 +139,27 @@ pub mod pallet {
                     for key in expired {
                         <Reports<T>>::remove(key);
                     }
+
+                    // clean expired geodes
+                    let mut expired = Vec::<T::AccountId>::new();
+                    pallet_geode::RegisteredGeodes::<T>::iter()
+                        .map(|(key, start)| {
+                            if start + ATTESTATION_EXPIRY_BLOCK_NUMBER < now {
+                                expired.push(key);
+                            }
+                        })
+                        .all(|_| true);
+                    for key in expired {
+                        <pallet_geode::Module<T>>::remove_geode(key, None)
+                            .map_err(|e| {
+                                debug!("{:?}", e);
+                            })
+                            .ok();
+                    }
                 }
                 Err(_) => {}
             }
+            0
         }
     }
 

--- a/pallets/liveness/src/lib.rs
+++ b/pallets/liveness/src/lib.rs
@@ -150,7 +150,7 @@ pub mod pallet {
                         })
                         .all(|_| true);
                     for key in expired {
-                        <pallet_geode::Module<T>>::remove_geode(key, None)
+                        <pallet_geode::Module<T>>::detach_geode(pallet_geode::DetachOption::Remove, key, None)
                             .map_err(|e| {
                                 debug!("{:?}", e);
                             })

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -122,7 +122,7 @@ where
         pool.clone(),
         automata_runtime::TransactionConverter,
         network.clone(),
-        pending_transactions.clone(),
+        pending_transactions,
         signers,
         overrides_map,
         backend,
@@ -139,7 +139,7 @@ where
     io.extend_with(EthPubSubApiServer::to_delegate(EthPubSubApi::new(
         pool.clone(),
         client.clone(),
-        network.clone(),
+        network,
         SubscriptionManager::<HexEncodedIdProvider>::with_id_provider(
             HexEncodedIdProvider::default(),
             Arc::new(subscription_task_executor),
@@ -150,9 +150,7 @@ where
         client.clone(),
     )));
 
-    io.extend_with(GeodeServer::to_delegate(geode::GeodeApi::new(
-        client.clone(),
-    )));
+    io.extend_with(GeodeServer::to_delegate(geode::GeodeApi::new(client)));
 
     io
 }


### PR DESCRIPTION
In this PR, the following logics are implemented:

1. Remove registered Geode if remaining not attested for a certain block number.
2. Mechanism for toggling Geode online/offline
3. Update geode's promise
4. Refactoring on some existing functions and new Error/Event adding. 
5. Format fix and clippy fix