### PR TITLE
update actions/checkout from v2 to v4 

### DIFF
--- a/.github/workflows/publish-release-dockers.yaml
+++ b/.github/workflows/publish-release-dockers.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       DOCKER_REPO: atactr/automata
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/publish-release-runtime.yaml
+++ b/.github/workflows/publish-release-runtime.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Build wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build wasm
         env:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-wasm]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Format
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2021-06-16
@@ -176,7 +176,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/cache@v2
         id: cache-sgx
         with:


### PR DESCRIPTION
Changes:

Updates all instances of actions/checkout@v2 to actions/checkout@v4
This is the last file requiring this update, all other files have been updated
Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.